### PR TITLE
FEAT: findScheduleByName 기능 추가

### DIFF
--- a/src/main/java/com/example/scheduler/controller/SchedulerController.java
+++ b/src/main/java/com/example/scheduler/controller/SchedulerController.java
@@ -33,6 +33,11 @@ public class SchedulerController {
         return new ResponseEntity<>(new ArrayList<>(schedulerService.findScheduleByUserInfo(user)), HttpStatus.OK);
     }
 
+    @GetMapping("/users/{name}-{id}")
+    public ResponseEntity<List<ToDoResponseDto>> findScheduleByName(@PathVariable String name, @PathVariable Long id) {
+        return new ResponseEntity<>(schedulerService.findScheduleByUserNameAndUserId(name, id), HttpStatus.OK);
+    }
+
     // 수정일 로 해당 날짜의 모든 일정 조회
     @GetMapping("/modified-date/{date}")
     public ResponseEntity<List<ToDoResponseDto>> findScheduleByModifiedDate(@PathVariable("date") String date) {

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
@@ -14,4 +14,6 @@ public interface SchedulerRepository {
     Optional<ToDo> saveToDo(ToDo toDo);
 
     List<ToDo> findToDoListByUserId(Long userId);
+
+    Optional<User> findUserByUserNameAndUserId(String userName, Long userId);
 }

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
@@ -95,7 +95,7 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
             public User mapRow(ResultSet rs, int rowNum) throws SQLException {
                 return User.builder()
                         .id(rs.getLong("id"))
-                        .name(rs.getString("name"))
+                        .name(rs.getString("name") + '-' + rs.getLong("id"))
                         .email(rs.getString("email"))
                         .build();
             }

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
@@ -39,7 +39,7 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
 
         return User.builder()
                 .id(key.longValue())
-                .name(user.getName())
+                .name(user.getName() + "-" + key.longValue())
                 .email(user.getEmail())
                 .build();
     }
@@ -47,8 +47,9 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
     @Override
     public Optional<User> findUserByEmailAndPassword(String email, String password) {
         // 사용자 검증 로직 수정
-        List<User> ret = jdbcTemplate.query("select * from user where email = ? and password = ?", userRowMapper(), email, password);
-        return ret.stream().findAny();
+        return jdbcTemplate.query("select * from user where email = ? and password = ?", userRowMapper(), email, password)
+                .stream()
+                .findAny();
     }
 
     @Override
@@ -78,6 +79,13 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
     @Override
     public List<ToDo> findToDoListByUserId(Long userId) {
         return jdbcTemplate.query("select * from to_do where user_id = ?", toDoRowMapper(), userId);
+    }
+
+    @Override
+    public Optional<User> findUserByUserNameAndUserId(String userName, Long userId) {
+        return jdbcTemplate.query("select * from user where name = ? and id = ?", userRowMapper(), userName, userId)
+                .stream()
+                .findAny();
     }
 
     private RowMapper<User> userRowMapper () {

--- a/src/main/java/com/example/scheduler/service/SchedulerService.java
+++ b/src/main/java/com/example/scheduler/service/SchedulerService.java
@@ -19,4 +19,6 @@ public interface SchedulerService {
     void deleteUser();
 
     void deleteToDoById(Long id);
+
+    List<ToDoResponseDto> findScheduleByUserNameAndUserId(String userName, Long userId);
 }

--- a/src/main/java/com/example/scheduler/service/SchedulerServiceImpl.java
+++ b/src/main/java/com/example/scheduler/service/SchedulerServiceImpl.java
@@ -21,7 +21,8 @@ public class SchedulerServiceImpl implements SchedulerService {
         this.schedulerRepository = schedulerRepository;
     }
 
-    @Override // 유저 email 로 해당유저가 등록한 모든 일정 조회
+    // 유저 email 로 해당유저가 등록한 모든 일정 조회
+    @Override
     public List<ToDoResponseDto> findScheduleByUserInfo(User user) {
 
         User savedUser = schedulerRepository.findUserByEmailAndPassword(user.getEmail(), user.getPassword())
@@ -31,17 +32,29 @@ public class SchedulerServiceImpl implements SchedulerService {
         return toDoList.stream().map(toDo -> new ToDoResponseDto(toDo, savedUser)).toList();
     }
 
-    @Override // 수정일 로 해당 날짜의 모든 일정 조회
+    @Override
+    public List<ToDoResponseDto> findScheduleByUserNameAndUserId(String userName, Long userId) {
+        User savedUser = schedulerRepository.findUserByUserNameAndUserId(userName, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다 = " + userName + "-" + userId));
+
+        List<ToDo> toDoList = schedulerRepository.findToDoListByUserId(savedUser.getId());
+        return toDoList.stream().map(toDo -> new ToDoResponseDto(toDo, savedUser)).toList();
+    }
+
+    // 수정일 로 해당 날짜의 모든 일정 조회
+    @Override
     public List<ToDoResponseDto> findScheduleByModifiedDate(String date) {
         return List.of();
     }
 
-    @Override // D-DAY 로 해당 날짜의 모든 일정 조회
+    // D-DAY 로 해당 날짜의 모든 일정 조회
+    @Override
     public List<ToDoResponseDto> findScheduleByDay(String date) {
         return List.of();
     }
 
-    @Override // 일정 생성 to_do(registerd_date modified_date work) user (name password email)
+    // 일정 생성 to_do(registerd_date modified_date work) user (name password email)
+    @Override
     @Transactional
     public ScheduleResponseDto saveSchedule(User user, ToDo toDo) {
         // 사용자가 존재하는지 확인
@@ -88,4 +101,6 @@ public class SchedulerServiceImpl implements SchedulerService {
     public void deleteToDoById(Long id) {
 
     }
+
+
 }


### PR DESCRIPTION
```
FEAT: 사용자의 이름과 고유식별자로 일정을 찾는 기능
 - /api/schedule/users/{name}-{id} 값으로 PathVariable 을 전달
 - name 과 id 값으로 데이터베이스에서 User 조회
 - 사용자가 있다면 해당 사용자의 전체 일정을 반환
 - 사용자가 없다면 404 NOT FOUND 반환

REFACTOR: 사용자 반환 값의 이름을 name + '-' + id 로 수정
 - 같은 이름의 사용자가 있다면 이를 구별하기 위해서 id 값을 추가
```