### PR TITLE
FEAT: findScheduleByModifiedDate and findScheduleByTheDay 기능 추가

### DIFF
--- a/src/main/java/com/example/scheduler/comparator/ModifiedDateComparator.java
+++ b/src/main/java/com/example/scheduler/comparator/ModifiedDateComparator.java
@@ -1,0 +1,14 @@
+package com.example.scheduler.comparator;
+
+import com.example.scheduler.dto.ToDoResponseDto;
+
+import java.util.Comparator;
+
+public class ModifiedDateComparator implements Comparator<ToDoResponseDto> {
+
+    @Override
+    public int compare(ToDoResponseDto o1, ToDoResponseDto o2) {
+        return o1.getModifiedDate().compareTo(o2.getModifiedDate());
+    }
+
+}

--- a/src/main/java/com/example/scheduler/comparator/TheDayComparator.java
+++ b/src/main/java/com/example/scheduler/comparator/TheDayComparator.java
@@ -1,0 +1,12 @@
+package com.example.scheduler.comparator;
+
+import com.example.scheduler.dto.ToDoResponseDto;
+
+import java.util.Comparator;
+
+public class TheDayComparator implements Comparator<ToDoResponseDto> {
+    @Override
+    public int compare(ToDoResponseDto o1, ToDoResponseDto o2) {
+        return o1.getDate().compareTo(o2.getDate());
+    }
+}

--- a/src/main/java/com/example/scheduler/controller/SchedulerController.java
+++ b/src/main/java/com/example/scheduler/controller/SchedulerController.java
@@ -1,5 +1,7 @@
 package com.example.scheduler.controller;
 
+import com.example.scheduler.comparator.ModifiedDateComparator;
+import com.example.scheduler.comparator.TheDayComparator;
 import com.example.scheduler.dto.*;
 import com.example.scheduler.entity.ToDo;
 import com.example.scheduler.entity.User;
@@ -8,8 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -30,7 +32,7 @@ public class SchedulerController {
                 .password(dto.getPassword())
                 .build();
 
-        return new ResponseEntity<>(new ArrayList<>(schedulerService.findScheduleByUserInfo(user)), HttpStatus.OK);
+        return new ResponseEntity<>(schedulerService.findScheduleByUserInfo(user), HttpStatus.OK);
     }
 
     @GetMapping("/users/{name}-{id}")
@@ -40,13 +42,33 @@ public class SchedulerController {
 
     // 수정일 로 해당 날짜의 모든 일정 조회
     @GetMapping("/modified-date/{date}")
-    public ResponseEntity<List<ToDoResponseDto>> findScheduleByModifiedDate(@PathVariable("date") String date) {
-        return new ResponseEntity<>(new ArrayList<>(schedulerService.findScheduleByModifiedDate(date)), HttpStatus.OK);
+    public ResponseEntity<List<ToDoResponseDto>> findScheduleByModifiedDate(
+            @PathVariable("date") LocalDate date,
+            @RequestParam(defaultValue = "asc") String order
+    ) {
+        List<ToDoResponseDto> list = schedulerService.findScheduleByModifiedDate(date);
+
+        if ("desc".equals(order)) {
+            list.sort(new ModifiedDateComparator().reversed());
+        }
+
+        return new ResponseEntity<>(list, HttpStatus.OK);
     }
 
-    @GetMapping("/d-day/{date}") // D-DAY 로 해당 날짜의 모든 일정 조회
-    public ResponseEntity<List<ToDoResponseDto>> findScheduleByDay(@PathVariable("date") String date) {
-        return new ResponseEntity<>(new ArrayList<>(schedulerService.findScheduleByDay(date)), HttpStatus.OK);
+    // D-DAY 로 해당 날짜의 모든 일정 조회
+    @GetMapping("/the-day/{date}")
+    public ResponseEntity<List<ToDoResponseDto>> findScheduleByTheDay(
+            @PathVariable("date") LocalDate date,
+            @RequestParam(defaultValue = "asc") String order
+    ) {
+
+         List<ToDoResponseDto> list = schedulerService.findScheduleByTheDay(date);
+
+        if ("desc".equals(order)) {
+            list.sort(new TheDayComparator().reversed());
+        }
+
+        return new ResponseEntity<>(list, HttpStatus.OK);
     }
 
     @PostMapping // 일정 생성 to_do(registerd_date modified_date work) user (name password email) schedule (date)

--- a/src/main/java/com/example/scheduler/dto/ToDoResponseDto.java
+++ b/src/main/java/com/example/scheduler/dto/ToDoResponseDto.java
@@ -31,4 +31,5 @@ public class ToDoResponseDto {
         this.modifiedDate = toDo.getModifiedDate();
         this.work = toDo.getWork();
     }
+
 }

--- a/src/main/java/com/example/scheduler/entity/ToDo.java
+++ b/src/main/java/com/example/scheduler/entity/ToDo.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ToDo {
     private Long id;
+    private Long userId;
     private LocalDateTime registeredDate;
     private LocalDateTime modifiedDate;
     private LocalDate date;

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
@@ -3,17 +3,24 @@ package com.example.scheduler.repository;
 import com.example.scheduler.entity.ToDo;
 import com.example.scheduler.entity.User;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface SchedulerRepository {
     User saveUser(User user);
 
+    Optional<ToDo> saveToDo(ToDo toDo);
+
+    Optional<User> findUserByUserId(Long userId);
+
     Optional<User> findUserByEmailAndPassword(String email, String password);
 
-    Optional<ToDo> saveToDo(ToDo toDo);
+    Optional<User> findUserByUserNameAndUserId(String userName, Long userId);
 
     List<ToDo> findToDoListByUserId(Long userId);
 
-    Optional<User> findUserByUserNameAndUserId(String userName, Long userId);
+    List<ToDo> findToDoListByModifiedDate(LocalDate date);
+
+    List<ToDo> findToDoListByTheDay(LocalDate date);
 }

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
@@ -11,6 +11,9 @@ import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,14 +48,6 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
     }
 
     @Override
-    public Optional<User> findUserByEmailAndPassword(String email, String password) {
-        // 사용자 검증 로직 수정
-        return jdbcTemplate.query("select * from user where email = ? and password = ?", userRowMapper(), email, password)
-                .stream()
-                .findAny();
-    }
-
-    @Override
     public Optional<ToDo> saveToDo(ToDo toDo) {
         SimpleJdbcInsert insert = new SimpleJdbcInsert(jdbcTemplate)
                 .withTableName("to_do")
@@ -77,15 +72,48 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
     }
 
     @Override
-    public List<ToDo> findToDoListByUserId(Long userId) {
-        return jdbcTemplate.query("select * from to_do where user_id = ?", toDoRowMapper(), userId);
+    public Optional<User> findUserByUserId(Long userId) {
+        return jdbcTemplate.query("select * from user where id = ?", userRowMapper(), userId)
+                .stream()
+                .findAny();
     }
+
+    @Override
+    public Optional<User> findUserByEmailAndPassword(String email, String password) {
+        // 사용자 검증 로직 수정
+        return jdbcTemplate.query("select * from user where email = ? and password = ?", userRowMapper(), email, password)
+                .stream()
+                .findAny();
+    }
+
 
     @Override
     public Optional<User> findUserByUserNameAndUserId(String userName, Long userId) {
         return jdbcTemplate.query("select * from user where name = ? and id = ?", userRowMapper(), userName, userId)
                 .stream()
                 .findAny();
+    }
+
+    @Override
+    public List<ToDo> findToDoListByUserId(Long userId) {
+        return jdbcTemplate.query("select * from to_do where user_id = ?", toDoRowMapper(), userId);
+    }
+
+    @Override
+    public List<ToDo> findToDoListByModifiedDate(LocalDate date) {
+        LocalDateTime theDay = LocalDateTime.of(date, LocalTime.MIN);
+        LocalDateTime theDayAfter = LocalDateTime.of(date.plusDays(1), LocalTime.MIN);
+
+        return jdbcTemplate.query("select * from to_do where modified_date >= ? and modified_date < ?"
+                , toDoRowMapper()
+                , Timestamp.valueOf(theDay)
+                , Timestamp.valueOf(theDayAfter));
+
+    }
+
+    @Override
+    public List<ToDo> findToDoListByTheDay(LocalDate date) {
+        return jdbcTemplate.query("select * from to_do where date = ?", toDoRowMapper(), Date.valueOf(date));
     }
 
     private RowMapper<User> userRowMapper () {
@@ -109,6 +137,7 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
             public ToDo mapRow(ResultSet rs, int rowNum) throws SQLException {
                 return ToDo.builder()
                         .id(rs.getLong("id"))
+                        .userId(rs.getLong("user_id"))
                         .registeredDate(rs.getTimestamp("registered_date").toLocalDateTime())
                         .modifiedDate(rs.getTimestamp("modified_date").toLocalDateTime())
                         .date(rs.getDate("date").toLocalDate())

--- a/src/main/java/com/example/scheduler/service/SchedulerService.java
+++ b/src/main/java/com/example/scheduler/service/SchedulerService.java
@@ -7,12 +7,13 @@ import com.example.scheduler.dto.UserResponseDto;
 import com.example.scheduler.entity.ToDo;
 import com.example.scheduler.entity.User;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface SchedulerService {
     List<ToDoResponseDto> findScheduleByUserInfo(User user);
-    List<ToDoResponseDto> findScheduleByModifiedDate(String date);
-    List<ToDoResponseDto> findScheduleByDay(String date);
+    List<ToDoResponseDto> findScheduleByModifiedDate(LocalDate date);
+    List<ToDoResponseDto> findScheduleByTheDay(LocalDate date);
     ScheduleResponseDto saveSchedule(User user, ToDo toDo);
     ToDoResponseDto updateToDo();
     UserResponseDto updateUser();

--- a/src/main/java/com/example/scheduler/service/SchedulerServiceImpl.java
+++ b/src/main/java/com/example/scheduler/service/SchedulerServiceImpl.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class SchedulerServiceImpl implements SchedulerService {
@@ -38,22 +40,55 @@ public class SchedulerServiceImpl implements SchedulerService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다 = " + userName + "-" + userId));
 
         List<ToDo> toDoList = schedulerRepository.findToDoListByUserId(savedUser.getId());
+
         return toDoList.stream().map(toDo -> new ToDoResponseDto(toDo, savedUser)).toList();
     }
 
     // 수정일 로 해당 날짜의 모든 일정 조회
     @Override
-    public List<ToDoResponseDto> findScheduleByModifiedDate(String date) {
-        return List.of();
+    public List<ToDoResponseDto> findScheduleByModifiedDate(LocalDate date) {
+
+        return schedulerRepository.findToDoListByModifiedDate(date)
+                .stream()
+                .map(toDo -> {
+                    User savedUser = schedulerRepository.findUserByUserId(toDo.getUserId())
+                            .orElseGet(() -> User.builder().name("임시 사용자")
+                                    .email("example@example.com")
+                                    .id(null)
+                                    .build());
+                    return new ToDoResponseDto(toDo, savedUser);
+                })
+                .collect(Collectors.toList());
     }
 
     // D-DAY 로 해당 날짜의 모든 일정 조회
     @Override
-    public List<ToDoResponseDto> findScheduleByDay(String date) {
-        return List.of();
+    public List<ToDoResponseDto> findScheduleByTheDay(LocalDate date) {
+
+        /*
+        * toList() 대신 collect(Collectors.toList()) 를 사용한 이유
+        * toList() 는 불변 객체를 반환한다 (The returned List is unmodifiable).
+        * client 코드에서 RequestParams 값 (order = asc or desc)에 따라서 list 를 재정렬 해야한다.
+        * 따라서 collect(Collectors.toList()) 로 stream 값을 반환하거나
+        * client 코드에서 new ArrayList<>(schedulerService.findScheduleByTheDay(date)) 로 코드를 수정해야한다.
+        * stream 에서 mutable list 를 반환하는게 가독성이 더 좋아보여서 선택했다.
+        */
+
+        return schedulerRepository.findToDoListByTheDay(date)
+                .stream()
+                .map(toDo -> {
+                    User savedUser = schedulerRepository.findUserByUserId(toDo.getUserId())
+                            .orElseGet(() -> User.builder()
+                                    .id(null)
+                                    .name("임시 사용자")
+                                    .email("example@example.com")
+                                    .build());
+                    return new ToDoResponseDto(toDo, savedUser);
+                })
+                .collect(Collectors.toList());
     }
 
-    // 일정 생성 to_do(registerd_date modified_date work) user (name password email)
+    // 일정 생성 to_do(registered_date modified_date work) user (name password email)
     @Override
     @Transactional
     public ScheduleResponseDto saveSchedule(User user, ToDo toDo) {


### PR DESCRIPTION
```
FEAT: findScheduleByModifiedDate 기능 추가

 - 수정일에 해당하는 일정을 반환한다

FEAT: findScheduleByTheDay 기능 추가

 - 처리되야 할 날짜에 해당하는 일정을 반환한다

공통사항

- api경로 마지막에 쿼리 스트링으로 정렬방식을 전달하면 그에 맞게 정렬되어 반환된다.
 - order=desc의 경우 PathVariable에 전달된 값을 기준으로 내림차순 정렬되어 반환된다.
 - order=asc 이거나 어떠한 값도 넣지 않았을 경우 자동으로 오름차순 정렬되어 반환된다.
```