### PR TITLE
FEAT: deleteUser and deleteToDo 추가

### DIFF
--- a/src/main/java/com/example/scheduler/controller/SchedulerController.java
+++ b/src/main/java/com/example/scheduler/controller/SchedulerController.java
@@ -23,18 +23,6 @@ public class SchedulerController {
         this.schedulerService = schedulerService;
     }
 
-    // 유저 email 과 password 로 해당유저가 등록한 모든 일정 조회
-    @PostMapping("/users")
-    public ResponseEntity<List<ToDoResponseDto>> findScheduleByEmailAndPassword(@RequestBody UserRequestDto dto) {
-
-        User user = User.builder()
-                .email(dto.getEmail())
-                .password(dto.getPassword())
-                .build();
-
-        return new ResponseEntity<>(schedulerService.findScheduleByUserInfo(user), HttpStatus.OK);
-    }
-
     // 사용자 명 으로 해당 날짜의 모든 일정 조회
     @GetMapping("/users/{name}-{id}")
     public ResponseEntity<List<ToDoResponseDto>> findScheduleByName(@PathVariable String name, @PathVariable Long id) {
@@ -107,15 +95,30 @@ public class SchedulerController {
         return new ResponseEntity<>(schedulerService.updateUser(), HttpStatus.OK);
     }
 
-    @DeleteMapping("/users/{id}") // 유저와 해당 유저의 모든 일정 삭제
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
-        schedulerService.deleteUser();
+    // 유저와 해당 유저의 모든 일정 삭제
+    @DeleteMapping("/users")
+    public ResponseEntity<Void> deleteUser(@RequestBody UserRequestDto dto) {
+        User user = User.builder()
+                .name(dto.getName())
+                .id(dto.getId())
+                .password(dto.getPassword())
+                .build();
+
+        schedulerService.deleteUser(user);
+
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @DeleteMapping("/users/{id}/to-dos/{toDoId}") // 해당 유저의 특정 일정 삭제
-    public ResponseEntity<Void> deleteToDo(@PathVariable Long id, @PathVariable Long toDoId) {
-        schedulerService.deleteToDoById(id);
+    // 해당 유저의 특정 일정 삭제
+    @DeleteMapping("/users/to-dos/{toDoId}")
+    public ResponseEntity<Void> deleteToDo(@PathVariable Long toDoId, @RequestBody UserRequestDto dto) {
+        User user = User.builder()
+                .name(dto.getName())
+                .id(dto.getId())
+                .password(dto.getPassword())
+                .build();
+
+        schedulerService.deleteToDo(user, toDoId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/scheduler/dto/UserRequestDto.java
+++ b/src/main/java/com/example/scheduler/dto/UserRequestDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class UserRequestDto {
-    private String email;
+    private Long id;
+    private String name;
     private String password;
 }

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
@@ -28,5 +28,5 @@ public interface SchedulerRepository {
 
     void deleteToDoListByUserId(Long userId);
 
-    int deleteUser(Long id);
+    void deleteUser(Long id);
 }

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
@@ -14,7 +14,7 @@ public interface SchedulerRepository {
 
     Optional<User> findUserByUserId(Long userId);
 
-    Optional<User> findUserByEmailAndPassword(String email, String password);
+    Optional<User> findUserByUserIdAndPassword(Long userId, String password);
 
     Optional<User> findUserByUserNameAndUserId(String userName, Long userId);
 
@@ -23,4 +23,10 @@ public interface SchedulerRepository {
     List<ToDo> findToDoListByModifiedDate(LocalDate date);
 
     List<ToDo> findToDoListByTheDay(LocalDate date);
+
+    int deleteToDo(Long toDoId);
+
+    void deleteToDoListByUserId(Long userId);
+
+    int deleteUser(Long id);
 }

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
@@ -127,8 +127,8 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
     }
 
     @Override
-    public int deleteUser(Long id) {
-        return jdbcTemplate.update("delete from user where id = ?", id);
+    public void deleteUser(Long id) {
+        jdbcTemplate.update("delete from user where id = ?", id);
     }
 
     private RowMapper<User> userRowMapper () {

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
@@ -79,9 +79,9 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
     }
 
     @Override
-    public Optional<User> findUserByEmailAndPassword(String email, String password) {
+    public Optional<User> findUserByUserIdAndPassword(Long userId, String password) {
         // 사용자 검증 로직 수정
-        return jdbcTemplate.query("select * from user where email = ? and password = ?", userRowMapper(), email, password)
+        return jdbcTemplate.query("select * from user where id = ? and password = ?", userRowMapper(), userId, password)
                 .stream()
                 .findAny();
     }
@@ -114,6 +114,21 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
     @Override
     public List<ToDo> findToDoListByTheDay(LocalDate date) {
         return jdbcTemplate.query("select * from to_do where date = ?", toDoRowMapper(), Date.valueOf(date));
+    }
+
+    @Override
+    public int deleteToDo(Long toDoId) {
+        return jdbcTemplate.update("delete from to_do where id = ?", toDoId);
+    }
+
+    @Override
+    public void deleteToDoListByUserId(Long userId) {
+        jdbcTemplate.update("delete from to_do where user_id = ?", userId);
+    }
+
+    @Override
+    public int deleteUser(Long id) {
+        return jdbcTemplate.update("delete from user where id = ?", id);
     }
 
     private RowMapper<User> userRowMapper () {

--- a/src/main/java/com/example/scheduler/service/SchedulerService.java
+++ b/src/main/java/com/example/scheduler/service/SchedulerService.java
@@ -11,15 +11,14 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface SchedulerService {
-    List<ToDoResponseDto> findScheduleByUserInfo(User user);
     List<ToDoResponseDto> findScheduleByModifiedDate(LocalDate date);
     List<ToDoResponseDto> findScheduleByTheDay(LocalDate date);
     ScheduleResponseDto saveSchedule(User user, ToDo toDo);
     ToDoResponseDto updateToDo();
     UserResponseDto updateUser();
-    void deleteUser();
+    void deleteUser(User user);
 
-    void deleteToDoById(Long id);
+    void deleteToDo(User user, Long toDoId);
 
     List<ToDoResponseDto> findScheduleByUserNameAndUserId(String userName, Long userId);
 }

--- a/src/main/java/com/example/scheduler/service/SchedulerServiceImpl.java
+++ b/src/main/java/com/example/scheduler/service/SchedulerServiceImpl.java
@@ -122,22 +122,18 @@ public class SchedulerServiceImpl implements SchedulerService {
     public void deleteUser(User user) {
 
         schedulerRepository.findUserByUserIdAndPassword(user.getId(), user.getPassword())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자의 이메일 혹은 비밀번호가 일치하지 않습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자의 ID 혹은 비밀번호가 일치하지 않습니다."));
 
         schedulerRepository.deleteToDoListByUserId(user.getId());
 
-        int deletedRow = schedulerRepository.deleteUser(user.getId());
-
-        if (deletedRow == 0) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "일정이 존재하지 않습니다 = " + user.getName() + "-" + user.getId());
-        }
+        schedulerRepository.deleteUser(user.getId());
     }
 
     @Override
     public void deleteToDo(User user, Long toDoId) {
 
         schedulerRepository.findUserByUserIdAndPassword(user.getId(), user.getPassword())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자의 이메일 혹은 비밀번호가 일치하지 않습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자의 ID 혹은 비밀번호가 일치하지 않습니다."));
 
         int deletedRow = schedulerRepository.deleteToDo(toDoId);
 

--- a/src/main/java/com/example/scheduler/service/SchedulerServiceImpl.java
+++ b/src/main/java/com/example/scheduler/service/SchedulerServiceImpl.java
@@ -23,17 +23,6 @@ public class SchedulerServiceImpl implements SchedulerService {
         this.schedulerRepository = schedulerRepository;
     }
 
-    // 유저 email 로 해당유저가 등록한 모든 일정 조회
-    @Override
-    public List<ToDoResponseDto> findScheduleByUserInfo(User user) {
-
-        User savedUser = schedulerRepository.findUserByEmailAndPassword(user.getEmail(), user.getPassword())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다 = " + user.getEmail()));
-
-        List<ToDo> toDoList = schedulerRepository.findToDoListByUserId(savedUser.getId());
-        return toDoList.stream().map(toDo -> new ToDoResponseDto(toDo, savedUser)).toList();
-    }
-
     // 사용자 명 으로 해당 날짜의 모든 일정 조회
     @Override
     public List<ToDoResponseDto> findScheduleByUserNameAndUserId(String userName, Long userId) {
@@ -107,7 +96,7 @@ public class SchedulerServiceImpl implements SchedulerService {
          */
 
         // 그렇기 때문에 saveUser(user) 함수의 실행을 Null 체크 이후로 보장해야 한다.
-        User savedUser = schedulerRepository.findUserByEmailAndPassword(user.getEmail(), user.getPassword())
+        User savedUser = schedulerRepository.findUserByUserIdAndPassword(user.getId(), user.getPassword())
                 .orElseGet(() -> schedulerRepository.saveUser(user));
 
         // 새 일정을 추가
@@ -129,13 +118,32 @@ public class SchedulerServiceImpl implements SchedulerService {
     }
 
     @Override
-    public void deleteUser() {
+    @Transactional
+    public void deleteUser(User user) {
 
+        schedulerRepository.findUserByUserIdAndPassword(user.getId(), user.getPassword())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자의 이메일 혹은 비밀번호가 일치하지 않습니다."));
+
+        schedulerRepository.deleteToDoListByUserId(user.getId());
+
+        int deletedRow = schedulerRepository.deleteUser(user.getId());
+
+        if (deletedRow == 0) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "일정이 존재하지 않습니다 = " + user.getName() + "-" + user.getId());
+        }
     }
 
     @Override
-    public void deleteToDoById(Long id) {
+    public void deleteToDo(User user, Long toDoId) {
 
+        schedulerRepository.findUserByUserIdAndPassword(user.getId(), user.getPassword())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자의 이메일 혹은 비밀번호가 일치하지 않습니다."));
+
+        int deletedRow = schedulerRepository.deleteToDo(toDoId);
+
+        if (deletedRow == 0) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "일정이 존재하지 않습니다 = " + toDoId);
+        }
     }
 
 


### PR DESCRIPTION
```
FEAT: deleteUser 기능 추가
 
 - RequestBody로 사용자의 ID, 이름, 그리고 비밀번호를 포함하여 전달
 - ID (고유식별자) 와 비밀번호로 사용자 검증
 - 맞다면 사용자 및 사용자가 등록한 일정 모두 삭제
 - 아니라면 400 BAD REQUEST 반환
 
FEAT: deleteToDo 기능 추가
 
 -  RequestBody로 사용자의 ID, 일정 ID, 이름, 그리고 비밀번호를 포함하여 전달
 - ID (고유식별자) 와 비밀번호로 사용자 검증
 - 맞다면 해당 일정 삭제
 - 아니라면 400 BAD REQUEST 반환
 - 일정이 없다면 404 NOT FOUND 반환

REFACTOR: UserRequestDto 필드 수정
 - 기존 email과 password 로 검증하던 방식 -> 사용자 ID 와 password로 변경
 - 또한 URL 경로 DELETE /users/{name}-{id} -> DELETE /users 로 변경
 - 파라미터로 전달받던 사용자 ID 와 이름을 RequestBody에 포함하는 것으로 변경
```