### PR TITLE
FIX: password 타입 String -> Integer 미변경된 부분 수정

### DIFF
--- a/src/main/java/com/example/scheduler/dto/request/UserRequestDto.java
+++ b/src/main/java/com/example/scheduler/dto/request/UserRequestDto.java
@@ -1,9 +1,6 @@
 package com.example.scheduler.dto.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -21,9 +18,9 @@ public class UserRequestDto {
     @Pattern(regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$", message = "이메일 형식을 지켜주세요.")
     private String email;
 
-    @NotBlank (message = "비밀번호를 적어주세요.")
+    @NotNull(message = "비밀번호를 적어주세요.")
     @Min(value = 1, message = "비밀번호는 최소 1자리 입니다.")
-    @Max(value = 5, message = "비밀번호는 최대 5자리 입니다.")
+    @Max(value = 99999, message = "비밀번호는 최대 5자리 입니다.")
     private Integer password;
 
 }

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepository.java
@@ -15,9 +15,9 @@ public interface SchedulerRepository {
 
     Optional<User> findUserByUserId(Long userId);
 
-    Optional<User> findUserByUserIdAndPassword(Long userId, String password);
+    Optional<User> findUserByUserIdAndPassword(Long userId, Integer password);
 
-    User findUserByUserIdAndPasswordOrElseThrow(Long userId, String password);
+    User findUserByUserIdAndPasswordOrElseThrow(Long userId, Integer password);
 
     Optional<User> findUserByUserNameAndUserId(String userName, Long userId);
 

--- a/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
+++ b/src/main/java/com/example/scheduler/repository/SchedulerRepositoryImpl.java
@@ -82,14 +82,14 @@ public class SchedulerRepositoryImpl implements SchedulerRepository {
     }
 
     @Override
-    public Optional<User> findUserByUserIdAndPassword(Long userId, String password) {
+    public Optional<User> findUserByUserIdAndPassword(Long userId, Integer password) {
         return jdbcTemplate.query("select * from user where id = ? and password = ?", userRowMapper(), userId, password)
                 .stream()
                 .findAny();
     }
 
     @Override
-    public User findUserByUserIdAndPasswordOrElseThrow(Long userId, String password) {
+    public User findUserByUserIdAndPasswordOrElseThrow(Long userId, Integer password) {
         // 사용자 검증 로직 수정
         return jdbcTemplate.query("select * from user where id = ? and password = ?", userRowMapper(), userId, password)
                 .stream()


### PR DESCRIPTION
```
FIX: password 타입 String -> Integer 미변경된 부분 수정

 - UserRequestDto 필드 타입 변경에도 변경되지 않았던 Service Layer 와 Repository Layer 메서드 파라미터 타입 변경

FIX: UserRequestDto password 검증 실패 수정

 - String -> Integer 타입 변경으로 비밀번호 길이 제한 5자리 미적용 (기존 검증 코드 = @Max(value=5))
 - 5자리로 변경하려면 @Max(value=99999) 로 변경해야 한다. 
 - Integer 타입이기 때문에 password 는 정수의 크기로 검증이 된다.
```